### PR TITLE
Migration validation in a clean and better way

### DIFF
--- a/guts/exception.py
+++ b/guts/exception.py
@@ -315,6 +315,10 @@ class InstanceNotReadyForMigration(GutsException):
     safe = True
 
 
-class InvalidPowerState(Invalid):
+class MigrationValidationFailed(Invalid):
+    pass
+
+
+class InvalidPowerState(MigrationValidationFailed):
     message = _("Instance: %(instance_id)s cannot be migrated in its current "
                 "power state. Please shutdown virtual instance and retry.")

--- a/guts/migration/drivers/vsphere.py
+++ b/guts/migration/drivers/vsphere.py
@@ -128,7 +128,8 @@ class VSphereDriver(driver.MigrationDriver):
         vm = self._find_vm_by_uuid(vm_uuid)
         POWERED_OFF = vim.VirtualMachine.PowerState.poweredOff
         if not vm.runtime.powerState == POWERED_OFF:
-            raise exception.InvalidPowerState(instance_id='random')
+            return (False, exception.InvalidPowerState)
+        return (True, None)
 
     def download_vm_disks(self, context, vm_uuid, base_path):
         vm = self._find_vm_by_uuid(vm_uuid)


### PR DESCRIPTION
This patch-set removes raising, catching and then reraising of
exception during validation at hypervisor level. Now we return
a tuple(status_boolean, error_cls) instead.

This removes unnecessary warning and fixes unnecessary raising of
exception.

Please review. 